### PR TITLE
Call Shields.IO API

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,7 @@
+URL_PARAMETER_PAGE_ID=page_id
+URL_PARAMETER_LABEL=label
+URL_PARAMETER_COLOR=color
+URL_PARAMETER_SHIELDS_QUERY="style, logo, logoColor, logoWidth, link, labelColor, cacheSeconds"
+DEFAULT_LABEL_TEXT=visitors
+DEFAULT_MESSAGE_COLOR=118bee
 md5_key=guess

--- a/main.py
+++ b/main.py
@@ -1,13 +1,20 @@
 import datetime
 
 from flask import Flask, Response, request, render_template
-from pybadges import badge
 from hashlib import md5
 import requests
 from os import environ
 from dotenv import find_dotenv,load_dotenv
+from typing import Optional
 
 load_dotenv(find_dotenv())
+
+URL_PARAMETER_PAGE_ID = environ.get('URL_PARAMETER_PAGE_ID')
+URL_PARAMETER_LABEL = environ.get('URL_PARAMETER_LABEL')
+URL_PARAMETER_COLOR = environ.get('URL_PARAMETER_COLOR')
+URL_PARAMETER_SHIELDS_QUERY = environ.get('URL_PARAMETER_SHIELDS_QUERY').split(' ')
+DEFAULT_LABEL_TEXT = environ.get('DEFAULT_LABEL_TEXT')
+DEFAULT_MESSAGE_COLOR = environ.get('DEFAULT_MESSAGE_COLOR')
 
 app = Flask(__name__)
 
@@ -17,13 +24,18 @@ def invalid_count_resp(err_msg) -> Response:
     Return a svg badge with error info when cannot process repo_id param from request
     :return: A response with invalid request badge
     """
-    svg = badge(left_text="Error", right_text=err_msg,
-                whole_link="https://github.com/jwenjian/visitor-badge")
+    svg = requests.get('https://img.shields.io/badge/{label}-{message}-{color}?link={link}'.format(
+            label='Error',
+            message=err_msg,
+            color=DEFAULT_MESSAGE_COLOR,
+            link='https://github.com/jwenjian/visitor-badge'
+        )
+    )
     expiry_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
 
-    headers = {'Cache-Control': 'no-cache,max-age=0', 'Expires': expiry_time.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+    headers = {'Cache-Control': 'no-cache,max-age=0', 'Expires': expiry_time.strftime('%a, %d %b %Y %H:%M:%S GMT')}
 
-    return Response(response=svg, content_type="image/svg+xml", headers=headers)
+    return Response(response=svg, content_type='image/svg+xml', headers=headers)
 
 
 def update_counter(key):
@@ -41,29 +53,41 @@ def update_counter(key):
 @app.route("/badge")
 def visitor_svg() -> Response:
     """
-    Return a svg badge with latest visitor count of 'Referer' header value
+    Return a svg badge with latest visitor count of 'Referrer' header value
 
     :return: A svg badge with latest visitor count
     """
 
-    req_source = identity_request_source()
+    req_source = get_request_value(URL_PARAMETER_PAGE_ID)
 
     if not req_source:
-        return invalid_count_resp('Missing required param: page_id')
+        return invalid_count_resp(f'Missing required param: {URL_PARAMETER_PAGE_ID}')
 
     latest_count = update_counter(req_source)
 
     if not latest_count:
         return invalid_count_resp("Count API Failed")
 
-    svg = badge(left_text="visitors", right_text=str(latest_count))
+    label_text = get_request_value(URL_PARAMETER_LABEL)
+    color_value = get_request_value(URL_PARAMETER_COLOR)
+
+    shields_query_strings = list(filter(None, [get_request_value(p) for p in URL_PARAMETER_SHIELDS_QUERY]))
+
+    shields_url = 'https://img.shields.io/badge/{label}-{message}-{color}{query}'.format(
+        label=label_text if label_text else DEFAULT_LABEL_TEXT,
+        message=str(latest_count),
+        color=color_value if color_value and len(color_value) else DEFAULT_MESSAGE_COLOR,
+        query='?{}'.format('&'.join(shields_query_strings)) if shields_query_strings else ''
+    )
+
+    svg = requests.get(shields_url)
 
     expiry_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
 
     headers = {'Cache-Control': 'no-cache,max-age=0,no-store,s-maxage=0,proxy-revalidate',
-               'Expires': expiry_time.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+               'Expires': expiry_time.strftime('%a, %d %b %Y %H:%M:%S GMT')}
 
-    return Response(response=svg, content_type="image/svg+xml", headers=headers)
+    return Response(response=svg, content_type='image/svg+xml', headers=headers)
 
 
 @app.route("/index.html")
@@ -73,13 +97,19 @@ def index() -> Response:
     return render_template('index.html')
 
 
-def identity_request_source() -> str:
-    page_id = request.args.get('page_id')
-    if page_id is not None and len(page_id):
-        m = md5(page_id.encode('utf-8'))
-        m.update(environ.get('md5_key').encode('utf-8'))
-        return m.hexdigest()
-    return None
+def get_request_value(url_parameter_name: str) -> Optional[str]:
+    url_parameter_value = request.args.get(url_parameter_name)
+    if url_parameter_value is not None and len(url_parameter_value):
+        if url_parameter_name == URL_PARAMETER_PAGE_ID:
+            m = md5(url_parameter_value.encode('utf-8'))
+            m.update(environ.get('md5_key').encode('utf-8'))
+            return m.hexdigest()
+        elif url_parameter_name in URL_PARAMETER_SHIELDS_QUERY:
+            return f'{url_parameter_name}={url_parameter_value}'
+        else:
+            return url_parameter_value
+    else:
+        return None if url_parameter_value is None else url_parameter_value
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask
-pybadges
 gunicorn
 requests
 python-dotenv

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,22 @@
             </li>
         </ol>
         <p>or any other markdown content, please give an unique string to distinguish</p>
+        <h3>Shields.IO functionality</h3>
+        <p>
+            Visitor badge calls the Shields.IO API, so you can using most of their parameters to style your own badge.
+            Currently supported parameters are: <code>label</code>, <code>color</code>, <code>style</code>,
+            <code>logo</code>, <code>logoColor</code>, <code>logoWidth</code>, <code>link</code>,
+            <code>labelColor</code>, <code>cacheSeconds</code>. By default, <code>label</code> is 'visitors' and cannot
+            be an empty string, and <code>color</code> is #118bee.
+        </p>
+        <p>
+            For example, using this URL for an issue will give you a red message background, in the for-the-badge style
+            with a white GitHub logo before the label text:
+            <code>
+                https://visitor-badge.glitch.me/badge?page_id=jwenjian.visitor-badge.issue.1&color=red&style=for-the-badge&logo=GitHub&logoColor=FFFFFF
+            </code>
+            See <a href="https://shields.io/" target="_blank">Shields.IO</a> for further details.
+        </p>
     </article>
     <hr>
     <div id="faq">
@@ -143,7 +159,6 @@
             <p><a href="https://paypal.me/jwenjian/5" target="_blank">PayPal</a></p>
             <p><a title="WeChat Pay donation link">WeChat Pay(coming soon)</a></p>
             <p><a title="Ali Pay donation link">Ali Pay(coming soon)</a></p>
-            </p>
         </aside>
     </section>
 </main>


### PR DESCRIPTION
Amended code to remove dependency on pybadges package, and instead point directly to the [Shields.IO](https://shields.io/) API.

This allows users to modify the style, add logos, etc. to the visitor counts badge. Currently supported parameters are: `label`, `color`, `style`, `logo`, `logoColor`, `logoWidth`, `link`, `labelColor`, `cacheSeconds`. By default, `label` is 'visitors' and cannot be an empty string, and `color` is #118bee.

Updated index.html to reflect these additions as well.